### PR TITLE
Adds inspect() method to see rules applied to a class

### DIFF
--- a/src/rxs.js
+++ b/src/rxs.js
@@ -80,6 +80,16 @@
     return this;
   };
 
+  RXSRule.prototype.inspect = function() {
+    var style = this.getRule().style;
+    return Object.keys(style).reduce(function(props, r) {
+      if(style[r].length && isNaN(parseInt(r, 10))) {
+        props[r] = style[r];
+      }
+      return props;
+    }, {});
+  };
+
   var RXS = function(selector, props) {
     if (!selector || typeof selector !== 'string') {
       return false;

--- a/test/rxs.inspect.js
+++ b/test/rxs.inspect.js
@@ -1,0 +1,25 @@
+'use strict';
+var jsdom = require('jsdom').jsdom;
+var document = jsdom('<div id="test"></div>');
+var window = document.defaultView;
+var nodeRXS = require('../src/rxs.js');
+var expect = require('chai').expect;
+
+nodeRXS(window);
+var rxs = window.rxs;
+
+describe('rxs.inspect', function() {
+  var el = window.document.getElementById('test');
+  el.classList.add('rx-style');
+
+  it('should return an object of props on .inspect()', function() {
+    var p = {
+      display: 'block',
+      margin: '10px',
+    };
+    var r = rxs('.rx-style', p);
+
+    expect(r.inspect().display).to.equal(p.display);
+    expect(r.inspect().margin).to.equal(p.margin);
+  });
+});


### PR DESCRIPTION
## Updates

* adds `.inspect()` method
* adds tests for `.inspect()`

Works like:
```js

```js
rxs('.happy-class').inspect();
```
Results:
```js
{
  display: 'block',
  margin: '10px',
}
```

Resolves: https://github.com/ItsJonQ/rxs/issues/10