### PR TITLE
Adds rxs.remove() method

### DIFF
--- a/src/rxs.js
+++ b/src/rxs.js
@@ -41,7 +41,8 @@
 
   RXSRule.prototype.getRuleIndex = function() {
     if (!this.ruleIndex) {
-      this.ruleIndex = this.getRules().length;
+      var len = this.getRules().length;
+      this.ruleIndex = len ? len - 1 : 0;
     }
     return this.ruleIndex;
   };
@@ -50,6 +51,13 @@
     var index = this.getRuleIndex();
     this.getStyleSheet().insertRule(this.selector + ' { }', index);
     return this.getRules()[index];
+  };
+
+  RXSRule.prototype.removeRule = function() {
+    if (this.findRule()) {
+      this.getStyleSheet().deleteRule(this.getRuleIndex());
+    }
+    return this;
   };
 
   RXSRule.prototype.findRule = function() {
@@ -88,6 +96,10 @@
       }
       return props;
     }, {});
+  };
+
+  RXSRule.prototype.remove = function() {
+    return this.removeRule();
   };
 
   var RXS = function(selector, props) {

--- a/test/rxs.remove.js
+++ b/test/rxs.remove.js
@@ -1,0 +1,39 @@
+'use strict';
+var jsdom = require('jsdom').jsdom;
+var document = jsdom('<div id="test"></div>');
+var window = document.defaultView;
+var nodeRXS = require('../src/rxs.js');
+var expect = require('chai').expect;
+
+nodeRXS(window);
+var rxs = window.rxs;
+
+describe('rxs.inspect', function() {
+  var el = window.document.getElementById('test');
+  el.classList.add('rx-style');
+  var p = {
+    display: 'block',
+    margin: '10px',
+  };
+
+  it('should remove an rxs rule', function() {
+    var r = rxs('.rx-style', p);
+
+    // Rule should be added
+    expect(r.getRules().length).to.equal(1);
+    r.remove();
+    // Rule should be removed
+    expect(r.getRules().length).to.equal(0);
+  });
+
+  it('should not be able to remove a removed rule', function() {
+    var r = rxs('.a', p);
+    // Extra rules, totally 3 rules
+    rxs('.b', p);
+    rxs('.c', p);
+
+    r.remove(); // 3 rules -> 2
+    r.remove(); // Can't be removed again
+    expect(r.getRules().length).to.equal(2);
+  });
+});


### PR DESCRIPTION
## Update

* Adds ability to remove rules by using `.remove()` on an RXSRule instance
* Adds tests!

Example:
```js
rxs('.down-low-too-slow').remove(); // this removes the CSS rule
```

Resolves:
https://github.com/ItsJonQ/rxs/issues/3